### PR TITLE
fix: delete alerts after sending

### DIFF
--- a/scraper/src/alerting/mailfactory/mailAvailableFactory.ts
+++ b/scraper/src/alerting/mailfactory/mailAvailableFactory.ts
@@ -41,8 +41,7 @@ export class MailAvailableFactory implements MailFactory {
   }
 
   async cleanup(): Promise<MailFactory> {
-    // TODO: Restore this line
-    // await deleteAlert(this.alert._id!);
+    await deleteAlert(this.alert._id!);
 
     return this;
   }

--- a/scraper/src/alerting/mailfactory/mailDiscountFactory.ts
+++ b/scraper/src/alerting/mailfactory/mailDiscountFactory.ts
@@ -41,8 +41,7 @@ export class MailDiscountFactory implements MailFactory {
   }
 
   async cleanup(): Promise<MailFactory> {
-    // TODO: Restore this line
-    // await deleteAlert(this.alert._id!);
+    await deleteAlert(this.alert._id!);
 
     return this;
   }

--- a/scraper/src/scrapers/deepCheckItem.ts
+++ b/scraper/src/scrapers/deepCheckItem.ts
@@ -1,12 +1,10 @@
 import puppeteer, { Page } from 'puppeteer';
-import { milliseconds } from '@fdebijl/pog';
 
 import { Item } from '../domain';
 import { PERMA_SALE_ITEM_IDS, SELECTORS } from '../constants';
 import { clog } from '../index';
 import { LOGLEVEL } from '@fdebijl/clog';
 import { isItemBuyable } from './isItemBuyable';
-import { time } from 'console';
 
 export const deepCheckItem = async ({ item, page, skip404Check = false, skipPriceAssignment = false }: { item: Item, page?: Page, skip404Check?: boolean, skipPriceAssignment?: boolean }): Promise<Item> => {
   item = { ...item };

--- a/scraper/src/wayback.ts
+++ b/scraper/src/wayback.ts
@@ -35,6 +35,7 @@ const TARGET_ROOTS_2022_SHOP = [
 // TODO: Populate this with the shop URLs for the 2016-style shop
 // TODO: add a way to switch the selector set between 2016 and 2021 shop, and add 2016 selectors
 // Shop with the previous set of selectors, starting from 2016
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TARGET_ROOTS_2016_SHOP = [
 ];
 


### PR DESCRIPTION
These lines were commented out for debugging, but should be re-enabled now that alerts can actually go out.