### PR TITLE
feat: add uptime monitoring

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,11 +16,8 @@ Todo:
 - Devops/other
   - Add readmes
   - Add other markdown files such as security/contributing for github purposes
-  - Add heartbeat to uptimerobot
 - Scraper
-  - Split into two run types: hourly non-pricing runs and daily pricing runs: non-pricing runs do everything but enter a new Price, pricing runs do everything
-  - Save scraped image locally (to an NFS share, for example) instead of hotlinking Gaijin's versions, in case they get deleted
   - Improve timings/reduce timeout duration for wayback scrapes
   - Save all-404/no-memento items and skip those
-  - Bundles always have undetermined description language, even if it's actually English
+  - Bundles always have `undetermined` description language, even if it's actually English
   - Address archive.org rate limiting

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,6 +24,10 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+app.get(`/${PATH_PREFIX}/${API_VERSION}/status`, async (req, res) => {
+  res.status(200).send(JSON.stringify({ status: 'OK' }));
+});
+
 app.get(`/${PATH_PREFIX}/${API_VERSION}/items/current`, async (req, res) => {
   const items = await listCurrentItems();
   res.json(items);

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,5 +1,13 @@
 # Warthunder.cheap Scraper
 
-Placeholder readme
+The scraper for Warthunder.cheap, designed to run on a schedule to keep the database up to date.
 
-Invoke with --wayback to scrape from wayback machine instead of the live store.
+Flags:
+```bash
+  --wayback
+        Scrape from wayback machine instead of the live store
+  --pricing
+        Store pricing information for each scraped item
+  --imaging
+        Store images for each scraped item
+```

--- a/scraper/src/constants.ts
+++ b/scraper/src/constants.ts
@@ -79,3 +79,4 @@ export const SHOP_2016_SELECTORS: SelectorSet = {
 
 export const MEDIA_PATH = process.env.MEDIA_PATH || './media';
 export const LAUNCH_HEADLESS = process.env.LAUNCH_HEADLESS ? process.env.LAUNCH_HEADLESS === 'true' : true;
+export const HEARTBEAT_URL = process.env.HEARTBEAT_URL;

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -3,7 +3,7 @@ import { Price, listItems, insertPrice, upsertItem, } from 'wtcheap.shared';
 
 import { getCurrentItems, deepCheckItem } from './scrapers/index.js';
 import { availableAlertNeeded, discountAlertNeeded, triggerAlertsForAvailable, triggerAlertsForDiscount, triggerAlertsForItems } from './alerting/index.js';
-import { SHOP_2022_SELECTORS, TARGET_ROOTS } from './constants.js';
+import { HEARTBEAT_URL, SHOP_2022_SELECTORS, TARGET_ROOTS } from './constants.js';
 import { waybackMain } from './wayback.js';
 import { ensureIndices } from './db/ensureIndices.js';
 import { storeMedia } from './util/storeMedia.js';
@@ -82,6 +82,11 @@ const main = async () => {
   }
 
   clog.log(`Finished scraping run at ${new Date().toISOString()}`);
+
+  if (HEARTBEAT_URL) {
+    await fetch(HEARTBEAT_URL);
+  }
+
   process.exit(0);
 };
 

--- a/scraper/src/scrapers/getCurrentItems.ts
+++ b/scraper/src/scrapers/getCurrentItems.ts
@@ -101,6 +101,7 @@ export const getCurrentItems = async (
     return items;
   }
 
+  // TODO: Add try/catch here
   for await (const item of items) {
     clog.log(`Deep checking ${item.title}`, LOGLEVEL.DEBUG);
 

--- a/scraper/src/scrapers/getDetailsOnPage.ts
+++ b/scraper/src/scrapers/getDetailsOnPage.ts
@@ -14,6 +14,7 @@ type DetailsInfo = {
   shortDescription?: string;
 }
 
+// TODO: Only log selector set when we're on a wayback scraping run
 export const getDetailsOnPage = async ({ page, selectors }: { page: Page, selectors: SelectorSet }): Promise<DetailsInfo> => {
   switch (selectors) {
     case SHOP_2022_SELECTORS: {

--- a/scraper/src/wayback.ts
+++ b/scraper/src/wayback.ts
@@ -10,6 +10,7 @@ import { LAUNCH_HEADLESS, SHOP_2016_SELECTORS, SHOP_2021_SELECTORS, SHOP_2022_SE
 import { containsNonLatinCharacters, enqueueStoreMedia } from './util/index.js';
 
 const WAYBACK_MACHINE_PAGE_TIMEOUT = 60_000;
+const isImagingRun = process.argv.includes('--imaging');
 
 const processUnseenItem = async (item: Item, page: Page): Promise<Item | null> => {
   const liveLink = `${item.href}`;
@@ -72,10 +73,12 @@ const processUnseenItem = async (item: Item, page: Page): Promise<Item | null> =
     clog.log(`Upserting item ${deepCheckedItem.id} "${deepCheckedItem.title}" (Currently available?: ${deepCheckedItem.buyable})`, LOGLEVEL.DEBUG);
     await upsertItem(deepCheckedItem);
 
-    const archivePrefix = safeUrl.url.match(/https:\/\/web.archive.org\/web\/\d{14}/)?.[0] as string;
-    if (archivePrefix) {
-      const prefix = archivePrefix + 'im_/';
-      enqueueStoreMedia(item, prefix).catch(e => clog.log(`Error storing media for item ${item.id} "${item.title}": ${e}`, LOGLEVEL.WARN));
+    if (isImagingRun) {
+      const archivePrefix = safeUrl.url.match(/https:\/\/web.archive.org\/web\/\d{14}/)?.[0] as string;
+      if (archivePrefix) {
+        const prefix = archivePrefix + 'im_/';
+        enqueueStoreMedia(item, prefix).catch(e => clog.log(`Error storing media for item ${item.id} "${item.title}": ${e}`, LOGLEVEL.WARN));
+      }
     }
 
     return deepCheckedItem;
@@ -112,10 +115,12 @@ const scrapeRoot = async (root: { url: string, datetime: Date }, seenItems: Item
     // We already upsert here so that the item is in the DB, even if there are no memento's for the details page
     await upsertItem(item);
 
-    const archivePrefix = root.url.match(/https:\/\/web.archive.org\/web\/\d{14}/)?.[0] as string;
-    if (archivePrefix) {
-      const prefix = archivePrefix + 'im_/';
-      enqueueStoreMedia(item, prefix).catch(e => clog.log(`Error storing media for item ${item.id} "${item.title}": ${e}`, LOGLEVEL.WARN));
+    if (isImagingRun) {
+      const archivePrefix = root.url.match(/https:\/\/web.archive.org\/web\/\d{14}/)?.[0] as string;
+      if (archivePrefix) {
+        const prefix = archivePrefix + 'im_/';
+        enqueueStoreMedia(item, prefix).catch(e => clog.log(`Error storing media for item ${item.id} "${item.title}": ${e}`, LOGLEVEL.WARN));
+      }
     }
 
     const price: Price = {

--- a/shared/src/db/prices/forItem.ts
+++ b/shared/src/db/prices/forItem.ts
@@ -2,6 +2,7 @@ import { Price } from '../../domain/index.js';
 
 import { connect } from '../connect.js';
 
+// TODO: return distinct by date
 export const getPricesForItem = async (itemId: string): Promise<Price[]> => {
   const db = await connect();
   const collection = db.collection('prices');


### PR DESCRIPTION
Add a HEARTBEAT_URL env var to the scraper that gets invoked every run if present. Useful for hooking up to uptime monitoring services such as Uptimerobot. Also adds a status endpoint to the API for the same purpose.