### PR TITLE
feat: use path instead of query param for item deeplinking

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -6,11 +6,11 @@
   <title>Warthunder.cheap | War Thunder Store Discount Alerts</title>
   <meta name="description" content="Warthunder.cheap tracks prices and availability for items on the War Thunder store. You can sign up to get alerts when items go on sale or when discontinued items are back in the store.">
 
-  <link rel="stylesheet" href="css/wtcheap.css">
+  <link rel="stylesheet" href="/css/wtcheap.css">
 
-  <script src="js/lib/lazysizes.min.js"></script>
-  <script src="js/wtcheap.js" type="module"></script>
-  <script src="js/lib/chart.js" async></script>
+  <script src="/js/lib/lazysizes.min.js"></script>
+  <script src="/js/wtcheap.js" type="module"></script>
+  <script src="/js/lib/chart.js" async></script>
 
   <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -23,7 +23,7 @@
 
   <header>
     <div class="row center">
-      <img src="img/logo.svg" alt="Warthunder.cheap logo">
+      <img src="/img/logo.svg" alt="Warthunder.cheap logo">
       <div class="col">
         <h1>Warthunder.cheap</h1>
         <h2>War Thunder Store Tracker, Alerts & Archive</h2>

--- a/website/src/js/renderers/itemRenderer.js
+++ b/website/src/js/renderers/itemRenderer.js
@@ -138,7 +138,7 @@ export class ItemRenderer {
     const detailsButton = document.createElement('a');
     detailsButton.classList.add('item__details', 'button', 'secondary');
     detailsButton.textContent = 'View Details';
-    detailsButton.href = `?item=${this.data.id}`;
+    detailsButton.href = `/item/${this.data.id}`;
     detailsButton.addEventListener('click', (event) => {
       event.preventDefault();
       this.detailsRenderer.show(this.data);

--- a/website/src/js/util/paramManager.js
+++ b/website/src/js/util/paramManager.js
@@ -12,10 +12,11 @@ export class ParamManager {
 
   initParams() {
     const urlParams = new URLSearchParams(window.location.search);
+    const path = window.location.pathname;
 
     this.params = {
       partner: urlParams.get('partner'),
-      item: urlParams.get('item')
+      item: path.match(/item\/(?<id>[0-9]*)/)?.groups?.id,
     };
 
     if (this.params.partner) {
@@ -60,9 +61,9 @@ export class ParamManager {
     }
 
     if (this.params.item) {
-      url.searchParams.set('item', this.params.item);
+      url.pathname = `/item/${this.params.item}`;
     } else {
-      url.searchParams.delete('item');
+      url.pathname = '/';
     }
 
     window.history.pushState({}, '', url);


### PR DESCRIPTION
Most search engine indexers ignore query params for building the page graph, so we're switching to paths to make indexing easier.